### PR TITLE
Configure Inferno match as default data with real kills

### DIFF
--- a/src/main/java/com/tacticore/lambda/config/DataInitializer.java
+++ b/src/main/java/com/tacticore/lambda/config/DataInitializer.java
@@ -22,9 +22,9 @@ public class DataInitializer implements CommandLineRunner {
             dummyDataService.loadDummyData();
             System.out.println("Datos dummy inicializados exitosamente!");
             
-            System.out.println("Inicializando partida de prueba...");
-            preloadedDataService.loadTestMatch();
-            System.out.println("Partida de prueba inicializada exitosamente!");
+            System.out.println("Inicializando partida de Inferno...");
+            preloadedDataService.loadInfernoMatch();
+            System.out.println("Partida de Inferno inicializada exitosamente!");
             
         } catch (Exception e) {
             System.err.println("Error inicializando datos: " + e.getMessage());

--- a/src/main/java/com/tacticore/lambda/controller/DataController.java
+++ b/src/main/java/com/tacticore/lambda/controller/DataController.java
@@ -87,6 +87,7 @@ public class DataController {
         }
     }
     
+    
     // GET /api/data/status
     @GetMapping("/status")
     public ResponseEntity<Map<String, String>> getDataStatus() {

--- a/src/main/java/com/tacticore/lambda/service/PreloadedDataService.java
+++ b/src/main/java/com/tacticore/lambda/service/PreloadedDataService.java
@@ -1,12 +1,18 @@
 package com.tacticore.lambda.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tacticore.lambda.model.ChatMessageEntity;
+import com.tacticore.lambda.model.KillEntity;
 import com.tacticore.lambda.model.MatchEntity;
 import com.tacticore.lambda.repository.ChatMessageRepository;
+import com.tacticore.lambda.repository.KillRepository;
 import com.tacticore.lambda.repository.MatchRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +25,11 @@ public class PreloadedDataService {
     
     @Autowired
     private ChatMessageRepository chatMessageRepository;
+    
+    @Autowired
+    private KillRepository killRepository;
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();
     
     public void loadPreloadedData() {
         loadPreloadedMatches();
@@ -113,6 +124,121 @@ public class PreloadedDataService {
         chatMessageRepository.save(welcomeMessage);
         
         System.out.println("Partida de prueba creada: " + testMatch.getMatchId());
+    }
+    
+    public void loadInfernoMatch() {
+        // Verificar si ya existe la partida de Inferno
+        if (matchRepository.existsByMatchId("inferno_demo")) {
+            return; // Ya existe
+        }
+        
+        // Crear partida de Inferno con datos reales
+        MatchEntity infernoMatch = new MatchEntity(
+            "inferno_demo", 
+            "inferno1.dem", 
+            "de_inferno", 
+            64, 
+            107, 
+            "completed", 
+            false
+        );
+        
+        matchRepository.save(infernoMatch);
+        
+        // Crear mensaje de bienvenida del Bot para la partida de Inferno
+        ChatMessageEntity welcomeMessage = new ChatMessageEntity(
+            "inferno_demo",
+            "Bot",
+            "Partida de Inferno cargada. Analicemos las jugadas de este mapa clásico.",
+            LocalDateTime.now()
+        );
+        chatMessageRepository.save(welcomeMessage);
+        
+        System.out.println("Partida de Inferno creada: " + infernoMatch.getMatchId());
+        
+        // Cargar kills de Inferno
+        loadInfernoKills();
+    }
+    
+    private void loadInfernoKills() {
+        // Verificar si ya existen kills para la partida de Inferno
+        if (killRepository.count() > 0) {
+            return; // Ya hay kills cargados
+        }
+        
+        try {
+            // Cargar kills reales desde el archivo JSON
+            File infernoFile = new File("demos-jsons/inferno1.json");
+            if (!infernoFile.exists()) {
+                System.err.println("Archivo inferno1.json no encontrado en demos-jsons/");
+                return;
+            }
+            
+            JsonNode rootNode = objectMapper.readTree(infernoFile);
+            JsonNode predictionsNode = rootNode.path("predictions");
+            
+            if (predictionsNode.isArray()) {
+                int loadedKills = 0;
+                for (JsonNode killNode : predictionsNode) {
+                    try {
+                        KillEntity kill = createKillFromJson(killNode);
+                        if (kill != null) {
+                            killRepository.save(kill);
+                            loadedKills++;
+                        }
+                    } catch (Exception e) {
+                        System.err.println("Error cargando kill: " + e.getMessage());
+                    }
+                }
+                System.out.println("Kills de Inferno cargados: " + loadedKills);
+            }
+            
+        } catch (IOException e) {
+            System.err.println("Error leyendo archivo inferno1.json: " + e.getMessage());
+        }
+    }
+    
+    private KillEntity createKillFromJson(JsonNode killNode) {
+        try {
+            KillEntity kill = new KillEntity();
+            
+            // Datos básicos del kill
+            kill.setKillId(killNode.path("kill_id").asText());
+            kill.setMatchId("inferno_demo");
+            kill.setAttacker(killNode.path("attacker").asText());
+            kill.setVictim(killNode.path("victim").asText());
+            kill.setPlace(killNode.path("place").asText("Unknown"));
+            kill.setRound(killNode.path("round").asInt());
+            kill.setWeapon(killNode.path("weapon").asText());
+            kill.setHeadshot(killNode.path("headshot").asBoolean(false));
+            kill.setDistance(killNode.path("distance").asDouble(0.0));
+            kill.setTimeInRound(killNode.path("time_in_round").asDouble(0.0));
+            
+            // Contexto del kill
+            JsonNode contextNode = killNode.path("context");
+            if (!contextNode.isMissingNode()) {
+                kill.setKillTick(contextNode.path("kill_tick").asLong(0));
+                kill.setSide(contextNode.path("side").asText("t"));
+                kill.setAttackerX(contextNode.path("attacker_x").asDouble(0.0));
+                kill.setAttackerY(contextNode.path("attacker_y").asDouble(0.0));
+                kill.setAttackerZ(contextNode.path("attacker_z").asDouble(0.0));
+                kill.setVictimX(contextNode.path("victim_x").asDouble(0.0));
+                kill.setVictimY(contextNode.path("victim_y").asDouble(0.0));
+                kill.setVictimZ(contextNode.path("victim_z").asDouble(0.0));
+                kill.setAttackerHealth(contextNode.path("attacker_health").asDouble(100.0));
+                kill.setVictimHealth(contextNode.path("victim_health").asDouble(100.0));
+                kill.setFlashNear(contextNode.path("flash_near").asBoolean(false));
+                kill.setSmokeNear(contextNode.path("smoke_near").asBoolean(false));
+                kill.setMolotovNear(contextNode.path("molotov_near").asBoolean(false));
+                kill.setHeNear(contextNode.path("he_near").asBoolean(false));
+            }
+            
+            return kill;
+            
+        } catch (Exception e) {
+            System.err.println("Error creando KillEntity desde JSON: " + e.getMessage());
+            return null;
+        }
     }
     
     public void clearPreloadedData() {


### PR DESCRIPTION
- Add loadInfernoMatch() method to PreloadedDataService
- Load real kills from demos-jsons/inferno1.json (107 kills)
- Remove test match from startup initialization
- Add JSON parsing for kill data with full context
- Set Inferno as the only default match on app startup

The app now starts with a complete Inferno match including:
- Real player data (malbsMd, frozen, jcobbb, huNter, etc.)
- Actual weapons, rounds, and timing data
- Full kill context (positions, health, flash/smoke status)
- 107 kills from a real CS:GO match

# Pull Request

## 📝 Descripción
<!-- Describe brevemente los cambios realizados -->

## 🔧 Tipo de Cambio
- [ ] 🐛 Bug fix (cambio que corrige un problema)
- [ ] ✨ Nueva funcionalidad (cambio que agrega funcionalidad)
- [ ] 💥 Breaking change (cambio que puede causar problemas de compatibilidad)
- [ ] 📚 Documentación (cambio solo en documentación)
- [ ] 🎨 Refactoring (cambio que no agrega funcionalidad ni corrige bugs)
- [ ] ⚡ Performance (cambio que mejora el rendimiento)
- [ ] 🧪 Tests (agregar o modificar tests)

## 🧪 Testing
- [ ] Tests unitarios agregados/modificados
- [ ] Tests de integración ejecutados
- [ ] Tests manuales realizados
- [ ] CI/CD pipeline pasa exitosamente

## 📋 Checklist
- [ ] Código sigue las convenciones del proyecto
- [ ] Self-review del código realizado
- [ ] Comentarios agregados en código complejo
- [ ] Documentación actualizada si es necesario
- [ ] No hay warnings de compilación
- [ ] Tests pasan localmente

## 🔗 Issues Relacionados
<!-- Link a issues relacionados, ej: Fixes #123 -->

## 📸 Screenshots (si aplica)
<!-- Agregar screenshots si los cambios afectan la UI -->

## 📝 Notas Adicionales
<!-- Cualquier información adicional que los reviewers necesiten saber -->

